### PR TITLE
dockerfile, gitignore final binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@
 *.out
 
 # final binary
-terraform-cassandra-provider
+terraform-provider-cassandra

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# final binary
+terraform-cassandra-provider

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Start by building the application.
+FROM golang:1.10 as build
+
+WORKDIR /go/src/github.com/daryl-d/terraform-provider-cassandra
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build
+
+# Now copy it into our base image.
+FROM scratch
+USER 1000
+COPY --from=build /go/src/github.com/daryl-d/terraform-provider-cassandra/terraform-provider-cassandra /terraform-provider-cassandra
+ENTRYPOINT ["/terraform-provider-cassandra"]


### PR DESCRIPTION
While a Docker image for this app is useless on its own, it makes a nice
way to pull this provider into a larger image, such as that used by a CI
agent